### PR TITLE
Update build docs

### DIFF
--- a/build_docs.py
+++ b/build_docs.py
@@ -190,8 +190,8 @@ def run():
     #
     if '--noclean' not in cmd_switches:
         print("Cleaning up.")
-        check_and_remove_dir(BUILD_DIR)
-        check_and_remove_dir(DEPENDENCIES_DIR)
+        #check_and_remove_dir(BUILD_DIR)
+        #check_and_remove_dir(DEPENDENCIES_DIR)
 
     print("Finished! You'll find the built docs in the '%s' directory." %
             OUTPUT_DIR)

--- a/doc_source/basic-use.rst
+++ b/doc_source/basic-use.rst
@@ -1,4 +1,4 @@
-.. Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+.. Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0
    International License (the "License"). You may not use this file except in compliance with the
@@ -17,19 +17,27 @@ Using the |sdk-cpp|
         Initialize and set options to use the AWS SDK for C++.
     :keywords:
 
-To use the |sdk-cpp|, you should properly initialize it with :code:`Aws::InitAPI` before creating
-service clients and using them. You should then shut down the SDK with
-:code:`Aws::ShutdownAPI`.
-
-Both of these functions take an instance of :aws-cpp-struct:`Aws::SDKOptions
-<aws_1_1_s_d_k_options>`, which you can use to set additional run-time options for SDK calls.
+Applications that use the |sdk-cpp| must initialize it. Similarly, before the application 
+terminates, the SDK must be shut down. Both operations accept configuration options that 
+affect the initialization and shutdown processes and subsequent calls to the SDK.
 
 .. _sdk-initializing:
 
 Initializing and Shutting Down the SDK
 ======================================
 
-A basic skeleton application looks like this:
+All applications that use the |sdk-cpp| must include the file :file:`aws/core/Aws.h`.
+
+The |sdk-cpp| must be initialized by calling :code:`Aws::InitAPI`. Before the application 
+terminates, the SDK must be shut down by calling :code:`Aws::ShutdownAPI`. Each method accepts 
+an argument of :aws-cpp-struct:`Aws::SDKOptions<aws_1_1_s_d_k_options>`. All other calls to the 
+SDK can be performed between these two method calls.
+
+Best practice requires all |sdk-cpp| calls performed between :code:`Aws::InitAPI` and
+:code:`Aws::ShutdownAPI` either to be contained within a pair of curly braces or be invoked by 
+functions called between the two methods.
+
+A basic skeleton application is shown below.
 
 .. code-block:: cpp
 
@@ -45,25 +53,21 @@ A basic skeleton application looks like this:
       return 0;
    }
 
-.. admonition:: best practice
-
-   To properly shut down / clean up any service clients that you may initialize before
-   :code:`Aws::ShutdownAPI` is called, it's a *best practice* to make sure that all SDK calls
-   are made within a pair of curly-braces as shown above, or within another function called between
-   :code:`Aws::InitAPI` and :code:`Aws::ShutdownAPI`.
-
 .. _sdk-setting-options:
 
-Setting SDK options
+Setting SDK Options
 ===================
 
-The :aws-cpp-struct:`Aws::SDKOptions <aws_1_1_s_d_k_options>` struct shown in
-:ref:`sdk-initializing` provides a number of options you can set. You should send the same options
-object to both :code:`Aws::InitAPI` and :code:`Aws::ShutdownAPI`.
+The :aws-cpp-struct:`Aws::SDKOptions <aws_1_1_s_d_k_options>` struct contains
+SDK configuration options.
 
-A few examples:
+An instance of :aws-cpp-struct:`Aws::SDKOptions` is passed to the 
+:code:`Aws::InitAPI` and :code:`Aws::ShutdownAPI` methods. The same instance
+should be sent to both methods.
 
-* Turn logging on using the default logger:
+The following samples demonstrate some of the available options.
+
+* Turn logging on using the default logger
 
   .. code-block:: cpp
 
@@ -75,7 +79,7 @@ A few examples:
      }
      Aws::ShutdownAPI(options);
 
-* Install a custom memory manager:
+* Install a custom memory manager
 
   .. code-block:: cpp
 
@@ -88,7 +92,7 @@ A few examples:
      }
      Aws::ShutdownAPI(options);
 
-* Override the default HTTP client factory:
+* Override the default HTTP client factory
 
   .. code-block:: cpp
 
@@ -103,15 +107,15 @@ A few examples:
      }
      Aws::ShutdownAPI(options);
 
-.. note:: ``httpOptions`` takes a closure instead of a ``std::shared_ptr``. The SDK does this for
-   all of its factory functions because the memory manager will not yet be installed at the time you
-   will need to allocate this memory. Pass a closure to the SDK, and it will be called when it is
-   safe to do so. This simplest way to do this is with a Lambda expression.
+.. note:: ``httpOptions`` takes a closure rather than a ``std::shared_ptr``. Each of the SDK 
+    factory functions operates in this manner because at the time at which the factory memory 
+    allocation occurs, the memory manager has not yet been installed. By passing a closure to the 
+    method, the memory manager will be called to perform the memory allocation when it is safe to 
+    do so. A simple technique to accomplish this procedure is by using a Lambda expression.
 
 More Information
 ================
 
-For further examples of |sdk-cpp| application code, view the topics in the
-:doc:`programming-services` section. Each example contains a link to the full source code on GitHub,
-which you can use as a starting point for your own applications.
-
+Examples of |sdk-cpp| application code are described in the section 
+:doc:`programming-services`. Each example includes a link to the full source code on GitHub
+which can be used as a starting point for your own applications.

--- a/doc_source/build-cmake.rst
+++ b/doc_source/build-cmake.rst
@@ -8,6 +8,8 @@
    either express or implied. See the License for the specific language governing permissions and
    limitations under the License.
 
+.. highlight:: sh
+
 ####################################
 Building Your Application with CMake
 ####################################
@@ -20,8 +22,6 @@ Building Your Application with CMake
 CMake_ is a build tool that can manage your application's dependencies and create native makefiles
 suitable for the platform you're building on. It's an easy way to create and build projects using
 the |sdk-cpp|.
-
-.. highlight:: sh
 
 Setting Up a CMake Project
 ==========================

--- a/doc_source/cmake-params.rst
+++ b/doc_source/cmake-params.rst
@@ -1,4 +1,4 @@
-.. Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+.. Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0
    International License (the "License"). You may not use this file except in compliance with the
@@ -17,7 +17,7 @@ CMake Parameters
         Customizing AWS SDK for C++ builds with CMake parameters.
     :keywords:
 
-    Use the CMake_ parameters listed in this section to customize how your SDK builds.
+Use the CMake_ parameters listed in this section to customize how your SDK builds.
 
 You can set these options with CMake GUI tools or the command line by using :paramname:`-D`. For
 example::

--- a/doc_source/setup.rst
+++ b/doc_source/setup.rst
@@ -1,4 +1,4 @@
-.. Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+.. Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0
    International License (the "License"). You may not use this file except in compliance with the
@@ -10,16 +10,16 @@
 
 .. highlight:: sh
 
-##############################
-Setting Up the AWS SDK for C++
-##############################
+########################
+Setting Up the |sdk-cpp|
+########################
 
 .. meta::
     :description:
-        AWS SDK for C++ prequisites and requirements to get and set up the SDK.
+        |sdk-cpp| prerequisites and requirements to set up the SDK.
     :keywords:
 
-This section presents information about how to setup the AWS SDK for C++ on your development platform.
+This section presents information about how to set up the |sdk-cpp| on your development platform.
     
 Prerequisites
 =============
@@ -44,19 +44,16 @@ To use the |sdk-cpp|, you need:
 Additional Requirements for Linux Systems
 -----------------------------------------
 
-To compile on Linux, you must have the header files (``-dev`` packages) for :file:`libcurl`, :file:`libopenssl`,
-:file:`libuuid`, :file:`zlib`, and optionally, :file:`libpulse` for |POLlong| support. Typically, you'll
-find the
-packages in your system's package manager.
+To compile on Linux, you must have the header files (``-dev`` packages) for :file:`libcurl`, 
+:file:`libopenssl`, :file:`libuuid`, :file:`zlib`, and, optionally, :file:`libpulse` for 
+|POLlong| support. The packages are typically found by using the system's package manager.
 
-.. topic:: To install these packages on *Debian/Ubuntu-based systems*
-
+.. topic:: To install the packages on *Debian/Ubuntu-based systems*
    ::
 
       sudo apt-get install libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev libpulse-dev
 
-.. topic:: To install these packages on *Redhat/Fedora-based systems*
-
+.. topic:: To install the packages on *Redhat/Fedora-based systems*
    ::
 
       sudo dnf install libcurl-devel openssl-devel libuuid-devel pulseaudio-devel
@@ -100,14 +97,17 @@ installed on your system.
 
    #. Open a Windows command prompt and navigate to the vcpkg directory.
 
-   #. Integrate vcpkg into Visual Studio. You can `integrate <https://docs.microsoft.com/en-us/cpp/vcpkg#installation>`_
-      per project or per user (shown below) to avoid manually editing Visual C++ directory paths.::
+   #. Integrate vcpkg into Visual Studio. You can `integrate 
+      <https://docs.microsoft.com/en-us/cpp/vcpkg#installation>`_ per project or per user 
+      (shown below) to avoid manually editing Visual C++ directory paths.
+      ::
 
-	   vcpkg integrate install
+	      vcpkg integrate install
 
-   #. Install the |sdk-cpp| package. This package compiles the SDK and its dependencies. It can take awhile.::
+   #. Install the |sdk-cpp| package. This package compiles the SDK and its dependencies. It can take a while.
+      ::
 
-	   vcpkg install aws-sdk-cpp:x86-windows
+	      vcpkg install aws-sdk-cpp:x86-windows
 
    #. Open your project in Visual Studio.
 
@@ -247,6 +247,6 @@ Creating Release Builds
 Running Integration Tests
 -------------------------
 
-Several directories are appended with ``*integration-tests``. After you build your project, you can
-run these executables to ensure everything works correctly.
-
+Several directory names include the suffix ``*integration-tests``. After the project is
+built, the tests stored in these directories can be run to verify the project's correct 
+execution.


### PR DESCRIPTION
*Issue #, if available:*
During script cleanup, fails to delete the temporary build_dependencies directory.

*Description of changes:*
The directory was not deleted because it contained R/O files. Updated script changes R/O files to R/W and retries the deletion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
