### PR TITLE
Fix formatting of Windows filepath

### DIFF
--- a/doc_source/build-cmake.rst
+++ b/doc_source/build-cmake.rst
@@ -48,7 +48,7 @@ Setting CMAKE_PREFIX_PATH (Optional)
 ====================================
 
 By default, the AWS SDK for C++ on macOS, Linux, Android and other non-Windows platforms is installed
-into :file:`/usr/local` and :file:`\Program Files (x86)\aws-cpp-sdk-all\` on Windows.
+into :file:`/usr/local` and :file:`\Program Files (x86)\aws-cpp-sdk-all` on Windows.
 
 When you install the SDK into a non-default location, CMake needs to know where to find the file 
 :file:`AWSSDKConfig.cmake` so that it can properly resolve the AWS SDK libraries that your 


### PR DESCRIPTION
The trailing backslash likely breaks the formatting, so I've removed it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
