### PR TITLE
Data type for `followRedirects` in `Aws::Client::ClientConfiguration` is now an enum (used to be a bool)

### DIFF
--- a/doc_source/client-config.md
+++ b/doc_source/client-config.md
@@ -46,7 +46,7 @@ struct AWS_CORE_API ClientConfiguration
     std::shared_ptr<Aws::Utils::RateLimits::RateLimiterInterface> writeRateLimiter;
     std::shared_ptr<Aws::Utils::RateLimits::RateLimiterInterface> readRateLimiter;
     Aws::Http::TransferLibType httpLibOverride;
-    bool followRedirects;
+    Aws::Client::FollowRedirectsPolicy followRedirects;
     bool disableExpectHeader;
     bool enableClockSkewAdjustment;
     bool enableHostPrefixInjection;
@@ -108,7 +108,7 @@ References to the implementations of read and write rate limiters which are used
 Specifies the HTTP implementation returned by the default HTTP factory\. The default HTTP client for Windows is WinHTTP\. The default HTTP client for all other platforms is CURL\.
 
 **followRedirects**  
-Controls whether the HTTP stack follows 300 redirect codes\.
+Controls the behavior when handling HTTP 300 redirect codes\.
 
 **disableExpectHeader**  
 Applicable only for CURL HTTP clients\. By default, CURL adds an “Expect: 100\-Continue” header in an HTTP request to avoid sending the HTTP payload in situations where the server responds with an error immediately after receiving the header\. This behavior can save a round\-trip and is useful in situations where the payload is small and network latency is relevant\. The variable’s default setting is false\. If set to true, CURL is instructed to send both the HTTP request header and body payload together\.


### PR DESCRIPTION
The `followRedirects` [member variable](https://github.com/aws/aws-sdk-cpp/blob/ed15d51fbf335ed4720bdbc1d0a96a36580a8cb9/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h#L213-L216) in `Aws::Client::ClientConfiguration` has been an [enum](
https://github.com/aws/aws-sdk-cpp/blob/ed15d51fbf335ed4720bdbc1d0a96a36580a8cb9/aws-cpp-sdk-core/include/aws/core/client/ClientConfiguration.h#L35-L46) type with three options since https://github.com/aws/aws-sdk-cpp/commit/726a9a1573a53a87f47d716928e0ec143fe94bc7.

It is no longer a boolean.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.